### PR TITLE
Revamp for github workflow testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,31 @@
+name: Linux
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        raku-version:
+          - 'latest'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+      - name: Install Dependencies
+        run: |
+          apt-get install -y xclip
+          zef install --/test --deps-only .
+          zef install --/test App::Prove6
+      - name: Run Tests
+        run: prove6 -l t

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,4 +28,4 @@ jobs:
           zef install --/test --deps-only .
           zef install --/test App::Prove6
       - name: Run Tests
-        run: prove6 -l t
+        run: %*ENV<DISPLAY>="Xvfb"; prove6 -l t

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
           raku-version: ${{ matrix.raku-version }}
       - name: Install Dependencies
         run: |
-          apt-get install -y xclip
+          sudo apt-get install -y xclip
           zef install --/test --deps-only .
           zef install --/test App::Prove6
       - name: Run Tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
           raku-version: ${{ matrix.raku-version }}
       - name: Install Dependencies
         run: |
-          sudo apt-get install -y xclip
+          sudo apt-get install -y xclip xvfb
           zef install --/test --deps-only .
           zef install --/test App::Prove6
       - name: Run Tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,30 @@
+name: MacOS
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        raku-version:
+          - 'latest'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+      - name: Install Dependencies
+        run: |
+          zef install --/test --deps-only .
+          zef install --/test App::Prove6
+      - name: Run Tests
+        run: prove6 -l t

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,35 @@
+name: Win64
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+        raku-version:
+          - 'latest'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+      - name: Install Dependencies
+        run: |
+          choco install xclip
+          zef install --/test --deps-only .
+          zef install --/test App::Prove6
+      - name: Run Tests
+        run: |
+          raku -I. t/01-copy-to-clipboard.t
+          raku -I. t/02-from-clipboard.t
+          raku -I. t/03-synonyms.t
+        run: prove6 -l t

--- a/Changes
+++ b/Changes
@@ -1,0 +1,3 @@
+Revision history for Raku-Clipboard
+
+{{$NEXT}}

--- a/META6.json
+++ b/META6.json
@@ -1,22 +1,26 @@
 {
-  "name": "Clipboard",
-  "description": "Raku package for using clipboards of different operating systems. (I.e., copy and paste with any OS.)",
-  "version": "0.1.2",
-  "perl": "6.d",
+  "api": "0",
+  "auth": "zef:antononcube",
   "authors": [
     "Anton Antonov"
   ],
-  "auth": "zef:antononcube",
-  "depends": [],
-  "build-depends": [],
-  "test-depends": [],
+  "build-depends": [
+  ],
+  "depends": [
+  ],
+  "description": "Raku package for using clipboards of different operating systems. (I.e., copy and paste with any OS.)",
+  "license": "Artistic-2.0",
+  "name": "Clipboard",
+  "perl": "6.d",
   "provides": {
     "Clipboard": "lib/Clipboard.rakumod",
     "Clipboard::Linux": "lib/Clipboard/Linux.rakumod",
+    "Clipboard::Windows": "lib/Clipboard/Windows.rakumod",
     "Clipboard::macOS": "lib/Clipboard/macOS.rakumod"
   },
-  "resources": [],
-  "license": "Artistic-2.0",
+  "resources": [
+  ],
+  "source-url": "https://github.com/antononcube/Raku-Clipboard",
   "tags": [
     "clipboard",
     "pastebin",
@@ -24,6 +28,7 @@
     "pbcopy",
     "xclip"
   ],
-  "api": "0",
-  "source-url": "https://github.com/antononcube/Raku-Clipboard"
+  "test-depends": [
+  ],
+  "version": "0.1.2"
 }

--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,38 @@
+name = Foo
+
+[ReadmeFromPod]
+enable = false
+
+[UploadToZef]
+
+[Badges]
+provider = github-actions/linux.yml
+provider = github-actions/macos.yml
+provider = github-actions/windows.yml
+
+[PruneFiles]
+; if you want to prune files when packaging, then
+; filename = utils/tool.pl
+;
+; you can use Raku regular expressions
+; match = ^ 'xt/'
+
+[MetaNoIndex]
+; if you do not want to list some files in META6.json as "provides", then
+; filename = lib/Should/Not/List/Provides.rakumod
+
+[AutoScanPackages]
+; if you do not want mi6 to scan packages at all,
+; but you want to manage "provides" in META6.json by yourself, then:
+; enabled = false
+
+; execute some commands before 'mi6 build'
+[RunBeforeBuild]
+; %x will be replaced by $*EXECUTABLE
+; cmd = %x -e 'say "hello"'
+; cmd = %x -e 'say "world"'
+
+; execute some commands after `mi6 build`
+[RunAfterBuild]
+; cmd = some shell command here
+

--- a/lib/Clipboard.rakumod
+++ b/lib/Clipboard.rakumod
@@ -18,6 +18,19 @@ unit module Clipboard;
 #|   - 'xclip -selection clipboard' on Linux.
 proto copy-to-clipboard(|) is export(:DEFAULT, :ALL, :long-names) {*}
 
+do given $*DISTRO {
+    when $_.is-win { 
+    require Clipboard::Windows;
+    }
+    when / macos / { 
+        require Clipboard::macOS;
+    }
+    default {
+        # Assuming it is Linux and it has xclip
+        require Clipboard::Linux;
+    }
+}
+
 multi sub copy-to-clipboard($payload, :$clipboard-command is copy = Whatever) {
 
     my $payload2 = $payload;

--- a/lib/Clipboard.rakumod
+++ b/lib/Clipboard.rakumod
@@ -1,5 +1,3 @@
-use v6.d;
-
 unit module Clipboard;
 
 #===========================================================
@@ -48,7 +46,7 @@ multi sub copy-to-clipboard($payload, :$clipboard-command is copy = Whatever) {
                         when $_ ~~ 'macos' { "pbcopy" }
                         default {
                             # Assuming it is Linux and it has xclip
-                            "xclip"
+                            "xclip -d Xvfb"
                         }
                     }
         }
@@ -98,7 +96,7 @@ multi sub paste(:$clipboard-command is copy = Whatever) {
                         when $_ ~~ 'macos' { "pbpaste" }
                         default {
                             # Assuming it is Linux and it has xclip
-                            "xclip -o"
+                            "xclip"
                         }
                     }
         }

--- a/lib/Clipboard.rakumod
+++ b/lib/Clipboard.rakumod
@@ -46,7 +46,7 @@ multi sub copy-to-clipboard($payload, :$clipboard-command is copy = Whatever) {
                         when $_ ~~ 'macos' { "pbcopy" }
                         default {
                             # Assuming it is Linux and it has xclip
-                            "xclip -d Xvfb"
+                            "xclip"
                         }
                     }
         }

--- a/lib/Clipboard/Linux.rakumod
+++ b/lib/Clipboard/Linux.rakumod
@@ -1,5 +1,3 @@
-use v6.d;
-
 unit module Clipboard::Linux;
 
 sub init-xclip-clipboard is export {

--- a/lib/Clipboard/Windows.rakumod
+++ b/lib/Clipboard/Windows.rakumod
@@ -1,5 +1,3 @@
-use v6.d;
-
 # I am not sure are there any_Windows-related Raku modules that can be used here.
 
 unit module Clipboard::Windows;

--- a/lib/Clipboard/macOS.rakumod
+++ b/lib/Clipboard/macOS.rakumod
@@ -1,5 +1,3 @@
-use v6.d;
-
 unit module Clipboard::macOS;
 
 sub init-osx-pbcopy-clipboard is export {

--- a/t/01-copy-to-clipboard.t
+++ b/t/01-copy-to-clipboard.t
@@ -1,6 +1,8 @@
 use lib '.';
 use lib './lib';
 
+%*ENV<DISPLAY> = "Xvfb";
+
 use Clipboard;
 use Test;
 

--- a/t/01-copy-to-clipboard.t
+++ b/t/01-copy-to-clipboard.t
@@ -1,5 +1,3 @@
-use v6.d;
-
 use lib '.';
 use lib './lib';
 

--- a/t/02-from-clipboard.t
+++ b/t/02-from-clipboard.t
@@ -1,7 +1,7 @@
-use v6.d;
-
 use lib '.';
 use lib './lib';
+
+%*ENV<DISPLAY> = "Xvfb";
 
 use Clipboard;
 use Test;

--- a/t/03-synonyms.t
+++ b/t/03-synonyms.t
@@ -1,7 +1,7 @@
-use v6.d;
-
 use lib '.';
 use lib './lib';
+
+%*ENV<DISPLAY> = "Xvfb";
 
 use Clipboard :cb-prefixed;
 use Test;


### PR DESCRIPTION
Tests are failing on Linux and Windows.

I removed "use v6.d;" from code since it's specified in the META6.json file.

For Linux github testing I tried to use the xvfb fake X server for xclip use with no success as of yet.

I will try the Clipboard on Linux interactively later today